### PR TITLE
feat: add node version management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9345,6 +9345,21 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-10.13.0.tgz",
+      "integrity": "sha512-IlfBQRq888Mp0nSMgYH6ONZLxD0ybKEOtD4WdiStebbQXg5EWBSs5RaaoYq4xBOW3g7TX8iqNz+gTHimC1fTJQ==",
+      "dev": true,
+      "requires": {
+        "node-bin-setup": "^1.0.0"
+      }
+    },
+    "node-bin-setup": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==",
+      "dev": true
+    },
     "node-gyp": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-version": "check-node-version --package"
   },
   "engines": {
-    "node": "~10.13.0",
+    "node": "^10.13.0",
     "npm": "^6.4.1"
   },
   "dependencies": {
@@ -68,6 +68,7 @@
     "@babel/preset-env": "^7.4.2",
     "babel-loader": "^8.0.4",
     "glob": "^7.1.3",
+    "node": "^10.13.0",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.3.0"
   }


### PR DESCRIPTION
## ✍️ Description
This adds the node package as a dependency so that `npm` and `npx` use the local version rather than system version.

- add `node@10.13.0`
- loosen the version range in engines.node `^10.13.0`



## The following steps outline the added experience by the pull request:
Should be able to run the project even if you system node version is incompatible.

- [ ] switch your system node version to a major version other than 10
- [ ] run `npm start` on master and observe the failure
- [ ] checkout this branch
- [ ] run `npm i`
- [ ] run `npm start` and 🙏 

### Before
<img width="714" alt="Screen Shot 2019-09-11 at 12 41 25 PM" src="https://user-images.githubusercontent.com/8847861/64717556-8862c980-d492-11e9-9327-40a0c99511e1.png">

### After
No errors 😎 