### PR TITLE
Move browserlist to package.json

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,1 +1,0 @@
-chrome >= 68, ie >= 11, edge >= 16, safari >=11

--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
     "node": "^10.13.0",
     "npm": "^6.4.1"
   },
+  "browserslist": [
+    "last 1 major version",
+    ">= 1%",
+    "Chrome >= 68",
+    "IE >= 11",
+    "Safari >= 11",
+    "Edge >= 16"
+  ],
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
     "autoprefixer": "^9.4.2",


### PR DESCRIPTION
# Issue #11 

## ✍️ Description

- Remove `.browserlistrc` and add a list of browser support strings to `package.json`. 
- Test `::placeholder` pseudoclass to see that browser prefixes are added.

<img width="780" alt="Screen Shot 2019-10-08 at 8 19 42 PM" src="https://user-images.githubusercontent.com/316762/66449795-25217400-ea0b-11e9-9332-2e06c7261a28.png">
