### PR TITLE
chore: Add CC Attribution-ShareAlike license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   - [package.json](package.json)
   - [src/data/global.yaml](src/data/global.yaml)
   - [README.md](README.md) (That's this file!)
+- **Consider changing the license** The Design System Starter is licensed with a CC Attribution-ShareAlike license. You should consider changing [the license file](LICENSE) if this doesn't fit the project you're starting with it.
 - **Start styling.** You can:
   - **Build a color palette** in [src/scss/settings/_variables.scss](src/scss/settings/_variables.scss)
   - **Adjust typography and default `<a>` styles** in [src/scss/tools/_mixins.scss](src/scss/tools/_mixins.scss)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "repository": "git@github.com:sparkbox/YOURNAMEHERE-design-system.git",
   "author": "Kasey Bonifacio <kasey@heysparkbox.com>",
-  "license": "MIT",
+  "license": "cc-by-sa-4.0",
   "scripts": {
     "prestart": "run-p clean node-version",
     "start": "node tasks/start.js",


### PR DESCRIPTION
This adds a LICENSE file containing information about the license.

This also adds a note about maybe removing the license, since this project is
used to other projects. People setting up new projects may not want this license
to come along for the ride.

fixes #6