### PR TITLE
chore (PR Template): Remove markdown link for Jira cards

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-# [Jira Card #__](https://sparkbox.atlassian.net/browse/CSC-)
+**Jira Card:** 
 
 ## ✍️ Description
 


### PR DESCRIPTION
This fixes a pet peeve of mine. Our PR template encourages filling in the Jira
card number _and_ a URL to a Jira card. But the number is already in the URL.

This _does_ make PRs slightly uglier since you see URLs instead of nice tidy
numbers. This tradeoff is worth it for less typing, IMO.

## The following steps outline the added experience by the pull request:

* [ ] When creating a new PR, now you can paste a Jira URL into place, with no need to manually type the issue number
