### PR TITLE
fix: Convert name spacing to more comprehendable words. Update button naming

### DIFF
--- a/src/data/spacing.yaml
+++ b/src/data/spacing.yaml
@@ -1,59 +1,59 @@
 spacing-classes:
-  - class: u-margin-bottom-none
+  - class: util-margin-bottom-none
     description: Removes margin from the bottom of an element.
-  - class: u-margin-bottom-xs
+  - class: util-margin-bottom-xs
     description: Adds an extra small amount of margin to the bottom of an element.
-  - class: u-margin-bottom-sm
+  - class: util-margin-bottom-sm
     description: Adds a small amount of margin to the bottom of an element.
-  - class: u-margin-bottom-md
+  - class: util-margin-bottom-md
     description: Adds a medium amount of margin to the bottom of an element.
-  - class: u-margin-bottom-lg
+  - class: util-margin-bottom-lg
     description: Adds a large amount of margin to the bottom of an element.
-  - class: u-margin-bottom-xl
+  - class: util-margin-bottom-xl
     description: Adds an extra large amount of margin to the bottom of an element.
-  - class: u-margin-bottom-xxl
+  - class: util-margin-bottom-xxl
     description: Adds an extra extra large amount of margin to the bottom of an element.
-  - class: u-margin-top-none
+  - class: util-margin-top-none
     description: Removes margin from the top of an element.
-  - class: u-margin-top-xs
+  - class: util-margin-top-xs
     description: Adds an extra small amount of margin to the top of an element.
-  - class: u-margin-top-sm
+  - class: util-margin-top-sm
     description: Adds a small amount of margin to the top of an element.
-  - class: u-margin-top-md
+  - class: util-margin-top-md
     description: Adds a medium amount of margin to the top of an element.
-  - class: u-margin-top-lg
+  - class: util-margin-top-lg
     description: Adds a large amount of margin to the top of an element.
-  - class: u-margin-top-xl
+  - class: util-margin-top-xl
     description: Adds an extra large amount of margin to the top of an element.
-  - class: u-margin-top-xxl
+  - class: util-margin-top-xxl
     description: Adds an extra extra large amount of margin to the top of an element.
 
 padding-classes:
-  - class: u-padding-bottom-none
+  - class: util-padding-bottom-none
     description: Removes padding from the bottom of an element.
-  - class: u-padding-bottom-xs
+  - class: util-padding-bottom-xs
     description: Adds an extra small amount of padding to the bottom of an element.
-  - class: u-padding-bottom-sm
+  - class: util-padding-bottom-sm
     description: Adds a small amount of padding to the bottom of an element.
-  - class: u-padding-bottom-md
+  - class: util-padding-bottom-md
     description: Adds a medium amount of padding to the bottom of an element.
-  - class: u-padding-bottom-lg
+  - class: util-padding-bottom-lg
     description: Adds a large amount of padding to the bottom of an element.
-  - class: u-padding-bottom-xl
+  - class: util-padding-bottom-xl
     description: Adds an extra large amount of padding to the bottom of an element.
-  - class: u-padding-bottom-xxl
+  - class: util-padding-bottom-xxl
     description: Adds an extra extra large amount of padding to the bottom of an element.
-  - class: u-padding-top-none
+  - class: util-padding-top-none
     description: Removes padding from the top of an element.
-  - class: u-padding-top-xs
+  - class: util-padding-top-xs
     description: Adds an extra small amount of padding to the top of an element.
-  - class: u-padding-top-sm
+  - class: util-padding-top-sm
     description: Adds a small amount of padding to the top of an element.
-  - class: u-padding-top-md
+  - class: util-padding-top-md
     description: Adds a medium amount of padding to the top of an element.
-  - class: u-padding-top-lg
+  - class: util-padding-top-lg
     description: Adds a large amount of padding to the top of an element.
-  - class: u-padding-top-xl
+  - class: util-padding-top-xl
     description: Adds an extra large amount of padding to the top of an element.
-  - class: u-padding-top-xxl
+  - class: util-padding-top-xxl
     description: Adds an extra extra large amount of padding to the top of an element.

--- a/src/markup/layout/page.hbs
+++ b/src/markup/layout/page.hbs
@@ -11,7 +11,7 @@
   {{> patterns.drizzle.partials.stylesheet-link-tags}}
 </head>
 <body class="{{body-class}}">
-  <a class="c-btn c-btn--primary c-skip-to-content" href="#main-content">Skip to main content</a>
+  <a class="cmp-button cmp-button--primary cmp-skip-to-content" href="#main-content">Skip to main content</a>
 
   <main id="main-content">
     {{#block "body"}}

--- a/src/markup/pages/demos/common-elements.hbs
+++ b/src/markup/pages/demos/common-elements.hbs
@@ -4,7 +4,7 @@ order: 20
 layout: page
 ---
 
-<div class="o-width-limiter o-width-limiter--sm u-margin-top-xl u-padding-bottom-xl">
+<div class="obj-width-limiter obj-width-limiter--sm util-margin-top-xl util-padding-bottom-xl">
 
   <h1>{{ title }}</h1>
 
@@ -35,7 +35,7 @@ layout: page
 
   <p>This paragraph is used to show space between the previous and following elements. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a ex nisl. Nullam sit amet sodales ante. Duis aliquet lorem sit amet erat commodo rhoncus.</p>
 
-  <div class="u-margin-top-lg u-margin-bottom-lg">
+  <div class="util-margin-top-lg util-margin-bottom-lg">
     <ol>
       <li>Lorem ipsum dolor sit amet</li>
       <li>Consectetur adipiscing elit</li>
@@ -46,7 +46,7 @@ layout: page
 
   <p>This paragraph is used to show space between the previous and following elements. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a ex nisl. Nullam sit amet sodales ante. Duis aliquet lorem sit amet erat commodo rhoncus.</p>
 
-  <div class="u-margin-top-lg u-margin-bottom-lg">
+  <div class="util-margin-top-lg util-margin-bottom-lg">
     <ul>
       <li>Lorem ipsum dolor sit amet</li>
       <li>Consectetur adipiscing elit</li>

--- a/src/markup/pages/documentation/grid.hbs
+++ b/src/markup/pages/documentation/grid.hbs
@@ -11,50 +11,50 @@ layout: drizzle
 
 <p class="drizzle-p">Most grid layouts are going to use either a two, three, or four column layout. The basic grid system includes all of the classes needed to create a simple layout with class names that are spelled out and easy to read.</p>
 
-<div class="o-grid">
-  <div class="o-grid__full drizzle-example-block"></div>
+<div class="obj-grid">
+  <div class="obj-grid__full drizzle-example-block"></div>
 
-  <div class="o-grid__half drizzle-example-block"></div>
-  <div class="o-grid__half drizzle-example-block"></div>
+  <div class="obj-grid__half drizzle-example-block"></div>
+  <div class="obj-grid__half drizzle-example-block"></div>
 
-  <div class="o-grid__third drizzle-example-block"></div>
-  <div class="o-grid__third drizzle-example-block"></div>
-  <div class="o-grid__third drizzle-example-block"></div>
+  <div class="obj-grid__third drizzle-example-block"></div>
+  <div class="obj-grid__third drizzle-example-block"></div>
+  <div class="obj-grid__third drizzle-example-block"></div>
 
-  <div class="o-grid__quarter drizzle-example-block"></div>
-  <div class="o-grid__quarter drizzle-example-block"></div>
-  <div class="o-grid__quarter drizzle-example-block"></div>
-  <div class="o-grid__quarter drizzle-example-block"></div>
+  <div class="obj-grid__quarter drizzle-example-block"></div>
+  <div class="obj-grid__quarter drizzle-example-block"></div>
+  <div class="obj-grid__quarter drizzle-example-block"></div>
+  <div class="obj-grid__quarter drizzle-example-block"></div>
 
-  <div class="o-grid__third drizzle-example-block"></div>
-  <div class="o-grid__two-third drizzle-example-block"></div>
+  <div class="obj-grid__third drizzle-example-block"></div>
+  <div class="obj-grid__two-third drizzle-example-block"></div>
 
-  <div class="o-grid__quarter drizzle-example-block"></div>
-  <div class="o-grid__three-quarter drizzle-example-block"></div>
+  <div class="obj-grid__quarter drizzle-example-block"></div>
+  <div class="obj-grid__three-quarter drizzle-example-block"></div>
 </div>
 
 <pre class="drizzle-u-borderTop drizzle-u-pad">
   <code class="language-markup">
-    &lt;div class="o-grid"&gt;
-      &lt;div class="o-grid__full"&gt;&lt;/div&gt;
+    &lt;div class="obj-grid"&gt;
+      &lt;div class="obj-grid__full"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__half"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__half"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__half"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__half"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__third"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__third"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__third"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__third"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__third"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__third"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__quarter"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__quarter"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__quarter"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__quarter"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__third"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__two-third"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__third"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__twobj-third"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__quarter"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__three-quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__quarter"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__three-quarter"&gt;&lt;/div&gt;
     &lt;/div&gt;
   </code>
 </pre>
@@ -65,108 +65,108 @@ layout: drizzle
     <th>Description</th>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid</code></td>
+    <td><code class="language-css">.obj-grid</code></td>
     <td>This is the class on the container that wraps around the grid columns.</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__full</code></td>
+    <td><code class="language-css">.obj-grid__full</code></td>
     <td>For columns that span the entire width of the grid (12 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__three-quarter</code></td>
+    <td><code class="language-css">.obj-grid__three-quarter</code></td>
     <td>For columns that three quarter width of the grid (9 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__two-third</code></td>
+    <td><code class="language-css">.obj-grid__twobj-third</code></td>
     <td>For columns that span two third width of the grid (8 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__half</code></td>
+    <td><code class="language-css">.obj-grid__half</code></td>
     <td>For columns that span half of the width of the grid (6 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__third</code></td>
+    <td><code class="language-css">.obj-grid__third</code></td>
     <td>For columns that span a third of the width of the grid (4 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__quarter</code></td>
+    <td><code class="language-css">.obj-grid__quarter</code></td>
     <td>For columns that span a quarter of the width of the grid (3 columns).</td>
   </tr>
 </table>
 
-<h2 class="drizzle-heading-2 u-margin-top-xxl">Responsive Grid</h2>
+<h2 class="drizzle-heading-2 util-margin-top-xxl">Responsive Grid</h2>
 
 <p class="drizzle-p">To adjust a the width of a column at different breakpoints you can add <code class="language-css">@sm</code>, <code class="language-css">@md</code>, <code class="language-css">@lg</code>, <code class="language-css">@xl</code> after any of the grid classes:</p>
 
-<div class="o-grid">
-  <div class="o-grid__half o-grid__third@sm drizzle-example-block"></div>
-  <div class="o-grid__half o-grid__third@sm drizzle-example-block"></div>
-  <div class="o-grid__full o-grid__third@sm drizzle-example-block"></div>
+<div class="obj-grid">
+  <div class="obj-grid__half obj-grid__third@sm drizzle-example-block"></div>
+  <div class="obj-grid__half obj-grid__third@sm drizzle-example-block"></div>
+  <div class="obj-grid__full obj-grid__third@sm drizzle-example-block"></div>
 
-  <div class="o-grid__full o-grid__quarter@md drizzle-example-block"></div>
-  <div class="o-grid__full o-grid__half@md drizzle-example-block"></div>
-  <div class="o-grid__full o-grid__quarter@md drizzle-example-block"></div>
+  <div class="obj-grid__full obj-grid__quarter@md drizzle-example-block"></div>
+  <div class="obj-grid__full obj-grid__half@md drizzle-example-block"></div>
+  <div class="obj-grid__full obj-grid__quarter@md drizzle-example-block"></div>
 </div>
 
 <pre class="drizzle-u-borderTop drizzle-u-pad">
   <code class="language-markup">
-    &lt;div class="o-grid"&gt;
-      &lt;div class="o-grid__half o-grid__third@sm"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__half o-grid__third@sm"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__full o-grid__third@sm"&gt;&lt;/div&gt;
+    &lt;div class="obj-grid"&gt;
+      &lt;div class="obj-grid__half obj-grid__third@sm"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__half obj-grid__third@sm"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__full obj-grid__third@sm"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__full o-grid__quarter@md"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__full o-grid__half@md"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__full o-grid__quarter@md"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__full obj-grid__quarter@md"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__full obj-grid__half@md"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__full obj-grid__quarter@md"&gt;&lt;/div&gt;
     &lt;/div&gt;
   </code>
 </pre>
 
-<h2 class="drizzle-heading-2 u-margin-top-xxl">Extended Grid</h2>
+<h2 class="drizzle-heading-2 util-margin-top-xxl">Extended Grid</h2>
 
 <p class="drizzle-p">In addition to the simple grid system there is an extended grid system that allows for any combination of a 12 column grid system. The extended grid system can also be used responsively in the same way that as the gimple grid system.</p>
 
 
-<div class="o-grid">
-  <div class="o-grid__1-12 drizzle-example-block"></div>
-  <div class="o-grid__11-12 drizzle-example-block"></div>
+<div class="obj-grid">
+  <div class="obj-grid__1-12 drizzle-example-block"></div>
+  <div class="obj-grid__11-12 drizzle-example-block"></div>
 
-  <div class="o-grid__2-12 drizzle-example-block"></div>
-  <div class="o-grid__10-12 drizzle-example-block"></div>
+  <div class="obj-grid__2-12 drizzle-example-block"></div>
+  <div class="obj-grid__10-12 drizzle-example-block"></div>
 
-  <div class="o-grid__3-12 drizzle-example-block"></div>
-  <div class="o-grid__9-12 drizzle-example-block"></div>
+  <div class="obj-grid__3-12 drizzle-example-block"></div>
+  <div class="obj-grid__9-12 drizzle-example-block"></div>
 
-  <div class="o-grid__4-12 drizzle-example-block"></div>
-  <div class="o-grid__8-12 drizzle-example-block"></div>
+  <div class="obj-grid__4-12 drizzle-example-block"></div>
+  <div class="obj-grid__8-12 drizzle-example-block"></div>
 
-  <div class="o-grid__5-12 drizzle-example-block"></div>
-  <div class="o-grid__7-12 drizzle-example-block"></div>
+  <div class="obj-grid__5-12 drizzle-example-block"></div>
+  <div class="obj-grid__7-12 drizzle-example-block"></div>
 
-  <div class="o-grid__6-12 drizzle-example-block"></div>
-  <div class="o-grid__6-12 drizzle-example-block"></div>
+  <div class="obj-grid__6-12 drizzle-example-block"></div>
+  <div class="obj-grid__6-12 drizzle-example-block"></div>
 </div>
 
 <pre class="drizzle-u-borderTop drizzle-u-pad">
   <code class="language-markup">
-    &lt;div class="o-grid"&gt;
-      &lt;div class="o-grid__1-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__11-12"&gt;&lt;/div&gt;
+    &lt;div class="obj-grid"&gt;
+      &lt;div class="obj-grid__1-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__11-12"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__2-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__10-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__2-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__10-12"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__3-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__9-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__3-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__9-12"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__4-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__8-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__4-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__8-12"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__5-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__7-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__5-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__7-12"&gt;&lt;/div&gt;
 
-      &lt;div class="o-grid__6-12"&gt;&lt;/div&gt;
-      &lt;div class="o-grid__6-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__6-12"&gt;&lt;/div&gt;
+      &lt;div class="obj-grid__6-12"&gt;&lt;/div&gt;
     &lt;/div&gt;
   </code>
 </pre>
@@ -177,55 +177,55 @@ layout: drizzle
     <th>Description</th>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid</code></td>
+    <td><code class="language-css">.obj-grid</code></td>
     <td>This is the class on the container that wraps around the grid columns.</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__12-12</code></td>
+    <td><code class="language-css">.obj-grid__12-12</code></td>
     <td>For columns that span the entire width of the grid (12 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__11-12</code></td>
+    <td><code class="language-css">.obj-grid__11-12</code></td>
     <td>For columns that span 11/12ths of the grid (11 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__10-12</code></td>
+    <td><code class="language-css">.obj-grid__10-12</code></td>
     <td>For columns that span 5/6ths width of the grid (10 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__9-12</code></td>
+    <td><code class="language-css">.obj-grid__9-12</code></td>
     <td>For columns that three quarter width of the grid (9 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__8-12</code></td>
+    <td><code class="language-css">.obj-grid__8-12</code></td>
     <td>For columns that span two third width of the grid (8 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__7-12</code></td>
+    <td><code class="language-css">.obj-grid__7-12</code></td>
     <td>For columns that span 7/12ths width of the grid (7 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__6-12</code></td>
+    <td><code class="language-css">.obj-grid__6-12</code></td>
     <td>For columns that span half of the width of the grid (6 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__5-12</code></td>
+    <td><code class="language-css">.obj-grid__5-12</code></td>
     <td>For columns that span 5/12ths width of the grid (5 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__4-12</code></td>
+    <td><code class="language-css">.obj-grid__4-12</code></td>
     <td>For columns that span a third of the width of the grid (4 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__3-12</code></td>
+    <td><code class="language-css">.obj-grid__3-12</code></td>
     <td>For columns that span a quarter of the width of the grid (3 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__2-12</code></td>
+    <td><code class="language-css">.obj-grid__2-12</code></td>
     <td>For columns that span one sixth width of the grid (2 columns).</td>
   </tr>
   <tr>
-    <td><code class="language-css">.o-grid__1-12</code></td>
+    <td><code class="language-css">.obj-grid__1-12</code></td>
     <td>For columns that span 1/12th width of the grid (1 columns).</td>
   </tr>
 </table>

--- a/src/markup/pages/documentation/page-width.hbs
+++ b/src/markup/pages/documentation/page-width.hbs
@@ -3,17 +3,17 @@ title: Page Width
 layout: page
 ---
 
-<div class="o-width-limiter u-padding-top-xl u-margin-bottom-xxl">
+<div class="obj-width-limiter util-padding-top-xl util-margin-bottom-xxl">
   <h1 class="drizzle-heading-1">{{title}}</h1>
 </div>
 
-<div class="u-margin-bottom-xxl">
+<div class="util-margin-bottom-xxl">
   <p class="drizzle-p">By default, text will touch the edge of the browser, like this.</p>
 </div>
 
-<div class="o-width-limiter u-margin-bottom-xxl">
+<div class="obj-width-limiter util-margin-bottom-xxl">
 
-  <p class="drizzle-p">The <code>o-width-limiter</code> object has two primary functions:</p>
+  <p class="drizzle-p">The <code>obj-width-limiter</code> object has two primary functions:</p>
 
   <ol>
     <li class="drizzle-p"><strong>Apply horizontal padding to create a page margin.</strong> When the screen is small, this prevents text from touching the edge of the browser.</li>
@@ -22,6 +22,6 @@ layout: page
 
 </div>
 
-<div class="o-width-limiter o-width-limiter--no-page-margin u-margin-bottom-xxl">
-  <p class="drizzle-p">If you want to use a <code>o-width-limiter</code> but don't want the included page margin, add an additional <code>o-width-limiter--no-page-margin</code> modifier class.</p>
+<div class="obj-width-limiter obj-width-limiter--no-page-margin util-margin-bottom-xxl">
+  <p class="drizzle-p">If you want to use a <code>obj-width-limiter</code> but don't want the included page margin, add an additional <code>obj-width-limiter--no-page-margin</code> modifier class.</p>
 </div>

--- a/src/markup/pages/documentation/spacing.hbs
+++ b/src/markup/pages/documentation/spacing.hbs
@@ -13,7 +13,7 @@ layout: drizzle
 
 {{#with (data 'spacing')}}
 
-<h2 class="drizzle-heading-2 u-margin-top-xxl">Margin</h2>
+<h2 class="drizzle-heading-2 util-margin-top-xxl">Margin</h2>
 
 <table>
   <thead>
@@ -36,7 +36,7 @@ layout: drizzle
   </tbody>
 </table>
 
-<h2 class="drizzle-heading-2 u-margin-top-xxl">Padding</h2>
+<h2 class="drizzle-heading-2 util-margin-top-xxl">Padding</h2>
 <table>
   <thead>
     <tr>
@@ -60,19 +60,19 @@ layout: drizzle
 {{/with}}
 
 
-<h2 class="drizzle-heading-2 u-margin-top-xxl">Responsive Spacing</h2>
+<h2 class="drizzle-heading-2 util-margin-top-xxl">Responsive Spacing</h2>
 <p class="drizzle-p">To adjust margin and padding at different breakpoints you can add <code class="language-css">@sm</code>, <code class="language-css">@md</code>, <code class="language-css">@lg</code>, <code class="language-css">@xl</code> after any of the spacing classes:</p>
 
 <div>
-  <div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg drizzle-example-block"></div>
-  <div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg drizzle-example-block"></div>
-  <div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg drizzle-example-block"></div>
+  <div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg drizzle-example-block"></div>
+  <div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg drizzle-example-block"></div>
+  <div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg drizzle-example-block"></div>
 </div>
 
 <pre class="drizzle-u-borderTop drizzle-u-pad">
   <code class="language-markup">
-    &lt;div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg"&gt;&lt;/div&gt;
-    &lt;div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg"&gt;&lt;/div&gt;
-    &lt;div class="u-margin-bottom-sm u-margin-bottom-md@md u-margin-bottom-lg@lg"&gt;&lt;/div&gt;
+    &lt;div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg"&gt;&lt;/div&gt;
+    &lt;div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg"&gt;&lt;/div&gt;
+    &lt;div class="util-margin-bottom-sm util-margin-bottom-md@md util-margin-bottom-lg@lg"&gt;&lt;/div&gt;
   </code>
 </pre>

--- a/src/markup/pages/index.hbs
+++ b/src/markup/pages/index.hbs
@@ -6,10 +6,10 @@ main-class: drizzle-white-bg
 
 <h1 class="drizzle-heading-1">{{data "global.companyName"}} Design System</h1>
 
-<p class="drizzle-p u-margin-bottom-xl">This UI toolkit is a highly-modular design system for rapid web page development. It contains different materials that can be assembled into more complex page layouts. It includes working examples, code snippets and documentation.</p>
+<p class="drizzle-p util-margin-bottom-xl">This UI toolkit is a highly-modular design system for rapid web page development. It contains different materials that can be assembled into more complex page layouts. It includes working examples, code snippets and documentation.</p>
 
 <h2 class="drizzle-heading-2">Demo Pages</h2>
-<div class="u-margin-bottom-lg">
+<div class="util-margin-bottom-lg">
   <ul>
     {{#each (pages "demos" sortby="order")}}
       <li>

--- a/src/markup/patterns/components/buttons/btn-with-icon.hbs
+++ b/src/markup/patterns/components/buttons/btn-with-icon.hbs
@@ -7,24 +7,24 @@ notes: |
 variantGroups:
   - name: Color
     set:
-      - c-btn--primary
-      - c-btn--secondary
-      - c-btn--tertiary
+      - cmp-button--primary
+      - cmp-button--secondary
+      - cmp-button--tertiary
   - name: Size
     set:
       - ""
-      - c-btn--lg
-      - c-btn--sm
+      - cmp-button--lg
+      - cmp-button--sm
   - name: Other
     set:
       - ""
-      - c-btn--full-width
+      - cmp-button--full-width
 ---
-<a href="#" class="c-btn">
+<a href="#" class="cmp-button">
   Click Me
 
-  <span class="c-btn__icon">
-    <svg class="c-icon c-icon--chevron" focusable="false" aria-hidden="true">
+  <span class="cmp-button__icon">
+    <svg class="cmp-icon cmp-icon--chevron" focusable="false" aria-hidden="true">
       <use xlink:href="/svg/symbol/svg/sprite.symbol.svg#icon-chevron"></use>
     </svg>
   </span>

--- a/src/markup/patterns/components/buttons/btn.hbs
+++ b/src/markup/patterns/components/buttons/btn.hbs
@@ -5,17 +5,17 @@ order: 1
 variantGroups:
   - name: Color
     set:
-      - c-btn--primary
-      - c-btn--secondary
-      - c-btn--tertiary
+      - cmp-button--primary
+      - cmp-button--secondary
+      - cmp-button--tertiary
   - name: Size
     set:
       - ""
-      - c-btn--lg
-      - c-btn--sm
+      - cmp-button--lg
+      - cmp-button--sm
   - name: Other
     set:
       - ""
-      - c-btn--full-width
+      - cmp-button--full-width
 ---
-<a href="#" class="c-btn">Click Me</a>
+<a href="#" class="cmp-button">Click Me</a>

--- a/src/markup/patterns/components/defaults/heading.hbs
+++ b/src/markup/patterns/components/defaults/heading.hbs
@@ -1,12 +1,12 @@
 ---
 name: Headings
 notes: |
-  Use these heading classes on any element to add heading styles. This lets you apply heading styles for alternate heading levels as well. For example, `.c-heading-1` can go on an `<h1>`, but it can also go on an `<h2>`, or any other element that should look like the styles defined in the `.c-heading-1` class.
+  Use these heading classes on any element to add heading styles. This lets you apply heading styles for alternate heading levels as well. For example, `.cmp-heading-1` can go on an `<h1>`, but it can also go on an `<h2>`, or any other element that should look like the styles defined in the `.cmp-heading-1` class.
 ---
 
-<div class="c-heading-1">Heading 1</div>
-<div class="c-heading-2">Heading 2</div>
-<div class="c-heading-3">Heading 3</div>
-<div class="c-heading-4">Heading 4</div>
-<div class="c-heading-5">Heading 5</div>
-<div class="c-heading-6">Heading 6</div>
+<div class="cmp-heading-1">Heading 1</div>
+<div class="cmp-heading-2">Heading 2</div>
+<div class="cmp-heading-3">Heading 3</div>
+<div class="cmp-heading-4">Heading 4</div>
+<div class="cmp-heading-5">Heading 5</div>
+<div class="cmp-heading-6">Heading 6</div>

--- a/src/markup/patterns/components/defaults/link.hbs
+++ b/src/markup/patterns/components/defaults/link.hbs
@@ -2,4 +2,4 @@
 notes: |
   Use this to create default-looking links.
 ---
-<a class="c-link" href="#">Click Me</a>
+<a class="cmp-link" href="#">Click Me</a>

--- a/src/markup/patterns/components/defaults/list--ordered.hbs
+++ b/src/markup/patterns/components/defaults/list--ordered.hbs
@@ -3,7 +3,7 @@ name: List (ordered)
 notes: |
   Use this to create default-looking ordered lists.
 ---
-<ol class="c-list c-list--ordered">
+<ol class="cmp-list cmp-list--ordered">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing elit</li>
   <li>Quisque viverra a ex at semper</li>

--- a/src/markup/patterns/components/defaults/list--unordered.hbs
+++ b/src/markup/patterns/components/defaults/list--unordered.hbs
@@ -3,7 +3,7 @@ name: List (unordered)
 notes: |
   Use this to create default-looking unordered lists.
 ---
-<ul class="c-list c-list--unordered">
+<ul class="cmp-list cmp-list--unordered">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing elit</li>
   <li>Quisque viverra a ex at semper</li>

--- a/src/markup/patterns/components/defaults/paragraph.hbs
+++ b/src/markup/patterns/components/defaults/paragraph.hbs
@@ -2,4 +2,4 @@
 notes: |
   Use this to create default-looking paragraphs.
 ---
-<p class="c-paragraph">Sed velit dignissim sodales ut eu sem integer vitae justo eget magna fermentum iaculis eu non diam phasellus vestibulum lorem sed risus. Venenatis urna cursus eget nunc scelerisque viverra mauris?</p>
+<p class="cmp-paragraph">Sed velit dignissim sodales ut eu sem integer vitae justo eget magna fermentum iaculis eu non diam phasellus vestibulum lorem sed risus. Venenatis urna cursus eget nunc scelerisque viverra mauris?</p>

--- a/src/markup/patterns/components/interactive/expandable-content.hbs
+++ b/src/markup/patterns/components/interactive/expandable-content.hbs
@@ -4,17 +4,17 @@ order: 20
 notes: |
   This can be used to provide content that's hidden by default, and opened by a user interaction. Additional styles can be added to the `&__button` and `&__content` elements to customize the look and feel of this component, while keeping the hide/show functionality in place.
 ---
-<div class="c-expandable-content">
-  <button class="c-btn c-btn--primary c-btn--sm c-btn--full-width js-toggler c-expandable-content__button" aria-expanded="false" id="unique-id">
+<div class="cmp-expandable-content">
+  <button class="cmp-button cmp-button--primary cmp-button--sm cmp-button--full-width js-toggler cmp-expandable-content__button" aria-expanded="false" id="unique-id">
     Details
 
-    <span class="c-btn__icon c-btn__icon--flip-when-expanded">
-      <svg class="c-icon c-icon--chevron" focusable="false" aria-hidden="true">
+    <span class="cmp-button__icon cmp-button__icon--flip-when-expanded">
+      <svg class="cmp-icon cmp-icon--chevron" focusable="false" aria-hidden="true">
         <use xlink:href="/svg/symbol/svg/sprite.symbol.svg#icon-chevron"></use>
       </svg>
     </span>
   </button>
-  <div class="c-expandable-content__content u-padding-top-md" aria-labelledby="unique-id" aria-hidden="false">
+  <div class="cmp-expandable-content__content util-padding-top-md" aria-labelledby="unique-id" aria-hidden="false">
     Nulla facilisi morbi tempus iaculis urna, id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et? Vel elit scelerisque mauris pellentesque pulvinar pellentesque habitant morbi tristique!
   </div>
 

--- a/src/markup/patterns/drizzle/partials/item.hbs
+++ b/src/markup/patterns/drizzle/partials/item.hbs
@@ -13,8 +13,8 @@ hidden: true
       {{#if data.variantGroups}}
         <button class="js-toggler drizzle-pattern__variant-button" aria-expanded="false" id="{{toSlug name}}-variants-toggle">
           Variants
-          <span class="c-btn__icon c-btn__icon--flip-when-expanded">
-            <svg class="c-icon c-icon--chevron" focusable="false" aria-hidden="true">
+          <span class="cmp-button__icon cmp-button__icon--flip-when-expanded">
+            <svg class="cmp-icon cmp-icon--chevron" focusable="false" aria-hidden="true">
               <use xlink:href="/svg/symbol/svg/sprite.symbol.svg#icon-chevron"></use>
             </svg>
           </span>
@@ -25,7 +25,7 @@ hidden: true
 
 
   {{#if data.variantGroups}}
-    <div class="drizzle-pattern__variant-box c-expandable-content__content u-padding-top-lg" aria-labelledby="{{toSlug name}}-variants-toggle" aria-hidden="false">
+    <div class="drizzle-pattern__variant-box cmp-expandable-content__content util-padding-top-lg" aria-labelledby="{{toSlug name}}-variants-toggle" aria-hidden="false">
       {{#each data.variantGroups}}
         <fieldset class="drizzle-pattern__variant-group">
           <legend class="drizzle-pattern__variant-legend">{{this.name}}</legend>
@@ -113,7 +113,7 @@ hidden: true
     </div>
   {{/if}}
   {{!-- Preview --}}
-  <div class="u-margin-top-lg">
+  <div class="util-margin-top-lg">
     <h3 class="drizzle-pattern__demo-box-title">View</h3>
     <div class="drizzle-pattern__demo-box drizzle-pattern__demo-box--view {{data.previewClass}}">
       {{{pattern id @root}}}

--- a/src/markup/patterns/drizzle/partials/sidebar.hbs
+++ b/src/markup/patterns/drizzle/partials/sidebar.hbs
@@ -9,7 +9,7 @@ hidden: true
   <div class="drizzle-nav__header">
     <p class="drizzle-nav__title"><a href="/" class="x">{{data "global.companyName"}} Design System</a></p>
 
-    <button class="drizzle-nav__toggle c-expandable-content__button js-toggler" id="nav-content">Menu</button>
+    <button class="drizzle-nav__toggle cmp-expandable-content__button js-toggler" id="nav-content">Menu</button>
 
     <!-- <a href="/" class="drizzle-Nav-title">{{data "global.companyName"}} Design System</a>
          
@@ -20,7 +20,7 @@ hidden: true
     <a class="drizzle-Nav-header-toggle" href="#nav" style="display: none;">a</a>
   </div>
 
-  <div class="drizzle-nav__content c-expandable-content__content" aria-hidden="false" id="nav-menu" aria-labelledby="nav-content">
+  <div class="drizzle-nav__content cmp-expandable-content__content" aria-hidden="false" id="nav-menu" aria-labelledby="nav-content">
 
     <div>
       <h2 class="drizzle-nav__collection-title">Components</h2>

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -84,7 +84,7 @@
 @import "components/paragraph";
 @import "components/link";
 @import "components/list";
-@import "components/btn";
+@import "components/button";
 @import "components/skip-to-content";
 @import "components/expandable-content";
 @import "components/icon";

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -1,4 +1,4 @@
-.c-btn {
+.cmp-button {
   // Reset default <button> styles
   @include unbuttonize;
 

--- a/src/scss/components/_expandable-content.scss
+++ b/src/scss/components/_expandable-content.scss
@@ -1,4 +1,4 @@
-.c-expandable-content {
+.cmp-expandable-content {
   &__button {
     position: relative;
 

--- a/src/scss/components/_heading.scss
+++ b/src/scss/components/_heading.scss
@@ -1,23 +1,23 @@
-.c-heading-1 {
+.cmp-heading-1 {
   @include h1;
 }
 
-.c-heading-2 {
+.cmp-heading-2 {
   @include h2;
 }
 
-.c-heading-3 {
+.cmp-heading-3 {
   @include h3;
 }
 
-.c-heading-4 {
+.cmp-heading-4 {
   @include h4;
 }
 
-.c-heading-5 {
+.cmp-heading-5 {
   @include h5;
 }
 
-.c-heading-6 {
+.cmp-heading-6 {
   @include h6;
 }

--- a/src/scss/components/_icon.scss
+++ b/src/scss/components/_icon.scss
@@ -1,4 +1,4 @@
-.c-icon {
+.cmp-icon {
   &--chevron {
     width: 1em;
     height: 0.6875em;

--- a/src/scss/components/_link.scss
+++ b/src/scss/components/_link.scss
@@ -1,3 +1,3 @@
-.c-link {
+.cmp-link {
   @include default-link;
 }

--- a/src/scss/components/_list.scss
+++ b/src/scss/components/_list.scss
@@ -1,4 +1,4 @@
-.c-list {
+.cmp-list {
   @include default-ol-ul;
 
   &--ordered {

--- a/src/scss/components/_paragraph.scss
+++ b/src/scss/components/_paragraph.scss
@@ -1,3 +1,3 @@
-.c-paragraph {
+.cmp-paragraph {
   @include default-paragraph;
 }

--- a/src/scss/components/_skip-to-content.scss
+++ b/src/scss/components/_skip-to-content.scss
@@ -1,4 +1,4 @@
-.c-skip-to-content {
+.cmp-skip-to-content {
   position: absolute;
   top: 1rem;
   left: -100%;

--- a/src/scss/object/_grid.scss
+++ b/src/scss/object/_grid.scss
@@ -18,27 +18,27 @@ $grid-count: 12;
     $val: '';
 
     @if $i == ceil($grid-count * 0.25) {
-      $val: ".o-grid__quarter#{$bp},";
+      $val: ".obj-grid__quarter#{$bp},";
     }
 
     @else if $i == ceil($grid-count * 0.3333) {
-      $val: ".o-grid__third#{$bp},";
+      $val: ".obj-grid__third#{$bp},";
     }
 
     @else if $i == ceil($grid-count * 0.5) {
-      $val: ".o-grid__half#{$bp},";
+      $val: ".obj-grid__half#{$bp},";
     }
 
     @else if $i == ceil($grid-count * 0.6666) {
-      $val: ".o-grid__two-third#{$bp}, .o-grid__two-thirds#{$bp},";
+      $val: ".obj-grid__two-third#{$bp}, .obj-grid__two-thirds#{$bp},";
     }
 
     @else if $i == ceil($grid-count * 0.75) {
-      $val: ".o-grid__three-quarter#{$bp}, .o-grid__three-quarters#{$bp},";
+      $val: ".obj-grid__three-quarter#{$bp}, .obj-grid__three-quarters#{$bp},";
     }
 
     @else if $i == $grid-count {
-      $val: ".o-grid__full#{$bp},";
+      $val: ".obj-grid__full#{$bp},";
     }
 
     @else {
@@ -46,14 +46,14 @@ $grid-count: 12;
     }
 
     #{$val}
-    .o-grid__#{$i}-#{$grid-count}#{$bp} {
+    .obj-grid__#{$i}-#{$grid-count}#{$bp} {
       @include column-span($i);
     }
   }
 }
 // stylelint-enable
 
-.o-grid {
+.obj-grid {
   @include clearfix;
   display: flex;
   flex-wrap: wrap;

--- a/src/scss/object/_width-limiter.scss
+++ b/src/scss/object/_width-limiter.scss
@@ -1,4 +1,4 @@
-.o-width-limiter {
+.obj-width-limiter {
   padding: 0 $page-margin;
 
   max-width: $max-page-width;

--- a/src/scss/utilities/_display.scss
+++ b/src/scss/utilities/_display.scss
@@ -1,23 +1,23 @@
-.u-display-none {
+.util-display-none {
   @include loop-mq {
     display: none;
   }
 }
 
-.u-display-block {
+.util-display-block {
   @include loop-mq {
     display: block;
   }
 }
 
-.u-display-inline {
+.util-display-inline {
   display: inline;
 }
 
-.u-display-inline-block {
+.util-display-inline-block {
   display: inline-block;
 }
 
-.u-display-visually-hidden {
+.util-display-visually-hidden {
   @include visually-hidden();
 }

--- a/src/scss/utilities/_spacing.scss
+++ b/src/scss/utilities/_spacing.scss
@@ -5,7 +5,7 @@ $side: (
   right
 );
 
-.u-margin {
+.util-margin {
   // This outputs regular spacing classes
   @each $side in $side {
     &-#{$side} {
@@ -33,7 +33,7 @@ $side: (
   }
 }
 
-.u-padding {
+.util-padding {
   // This outputs regular spacing classes
   @each $side in $side {
     &-#{$side} {

--- a/src/scss/utilities/_text.scss
+++ b/src/scss/utilities/_text.scss
@@ -1,15 +1,15 @@
-.u-text-center {
+.util-text-center {
   text-align: center;
 }
 
-.u-text-right {
+.util-text-right {
   text-align: right;
 }
 
-.u-text-left {
+.util-text-left {
   text-align: left;
 }
 
-.u-text-subtle {
+.util-text-subtle {
   opacity: 0.8;
 }


### PR DESCRIPTION
## ✍️ Description

Single letter namespacing can be hard to grok. This updates the name spacing to follow a more comprehensive naming strategy found in Sparkbox projects.

Also addresses the ever odd shortening of a short word.

## The following steps outline the added experience by the pull request:

* [x] Helps developers understand more code quickly without need for a key or docs.
